### PR TITLE
Treat env as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ After this, check with `lb-a` effects domain `front-a.foo.example.com`, and `lb-
   * If you set `SLACK_URL` environ, then changes are notified.
   * Pass `--check-id` if your health check has CheckID which is a consul default `service:{{service_name}}`.
 
+* `collector watch` respects environment variables:
+  * Which are useful working with systemd unit file
+  * `COLLECTOR_HOSTED_ZONE`, `COLLECTOR_DOMAIN` and `COLLECTOR_CHECK_ID`.
+  * Note: `COLLECTOR_DOMAIN` shoulw be splited with white space ` `
+
 ## Note
 
 * This product is exoerimental and before alpha release.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "0.3.0"
+const Version = "0.3.1"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/udzura/collector/collectorlib"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -34,6 +35,25 @@ func init() {
 	watchCmd.Flags().StringVarP(&hostedZone, "hosted-zone", "H", "", "Hosted zone to update")
 	watchCmd.Flags().StringVarP(&checkID, "check-id", "C", "", "CheckID to use for IP output")
 	watchCmd.Flags().StringSliceVarP(&domains, "domain", "D", []string{}, "Full domain name to keep global IPs")
+
+	viper.SetEnvPrefix("collector")
+	viper.BindEnv("hosted_zone")
+	viper.BindEnv("check_id")
+	viper.BindEnv("domain")
+
+	cobra.OnInitialize(initEnviron)
+}
+
+func initEnviron() {
+	if hostedZone == "" {
+		hostedZone = viper.GetString("hosted_zone")
+	}
+	if checkID == "" {
+		checkID = viper.GetString("check_id")
+	}
+	if len(domains) == 0 {
+		domains = viper.GetStringSlice("domain")
+	}
 }
 
 func runWatcher() int {


### PR DESCRIPTION
Respects `COLLECTOR_HOSTED_ZONE`, `COLLECTOR_DOMAIN` and `COLLECTOR_CHECK_ID`.

See README's diff.
