### PR TITLE
Fix trailing "\n"

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "0.3.2"
+const Version = "0.3.3"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/collectorlib/output.go
+++ b/collectorlib/output.go
@@ -9,7 +9,7 @@ func FindIPFromOutput(output string) string {
 			continue
 		}
 		if pair[0] == "ipaddr" {
-			return pair[1]
+			return strings.TrimSpace(pair[1])
 		}
 	}
 

--- a/collectorlib/output_test.go
+++ b/collectorlib/output_test.go
@@ -1,0 +1,35 @@
+package collectorlib
+
+import (
+	"testing"
+)
+
+func TestFindIPFromOutput(t *testing.T) {
+	str := "ipaddr:192.0.2.100"
+	expected := "192.0.2.100"
+	found := FindIPFromOutput(str)
+	if found != expected {
+		t.Errorf("Expect %s found, got %s", expected, found)
+	}
+
+	str = "ipaddr:192.0.2.101\n"
+	expected = "192.0.2.101"
+	found = FindIPFromOutput(str)
+	if found != expected {
+		t.Errorf("Expect %s found, got %s", expected, found)
+	}
+
+	str = "foo:bar buz\txxx:10.0.0.10\tipaddr:192.0.2.102\n"
+	expected = "192.0.2.102"
+	found = FindIPFromOutput(str)
+	if found != expected {
+		t.Errorf("Expect %s found, got %s", expected, found)
+	}
+
+	str = "foo:bar buz\txxx:10.0.0.10\n"
+	expected = ""
+	found = FindIPFromOutput(str)
+	if found != expected {
+		t.Errorf("Expect %s found, got %s", expected, found)
+	}
+}

--- a/collectorlib/request_test.go
+++ b/collectorlib/request_test.go
@@ -24,7 +24,7 @@ var testJson = `[
 	"Name": "Service 'nginx' check",
 	"Status": "passing",
 	"Notes": "",
-	"Output": "ipaddr:192.0.2.101",
+	"Output": "ipaddr:192.0.2.101\n",
 	"ServiceID": "redis",
 	"ServiceName": "redis"
       },
@@ -58,7 +58,7 @@ var testJson = `[
 	"Name": "Service 'nginx' check",
 	"Status": "passing",
 	"Notes": "",
-	"Output": "ipaddr:192.0.2.102",
+	"Output": "ipaddr:192.0.2.102\n",
 	"ServiceID": "redis",
 	"ServiceName": "redis"
       },
@@ -92,7 +92,7 @@ var testJson = `[
 	"Name": "Service 'nginx' check",
 	"Status": "passing",
 	"Notes": "",
-	"Output": "ipaddr:192.0.2.103",
+	"Output": "ipaddr:192.0.2.103\n",
 	"ServiceID": "redis",
 	"ServiceName": "redis"
       },
@@ -126,7 +126,7 @@ var testJson = `[
 	"Name": "Service 'nginx' check",
 	"Status": "failing",
 	"Notes": "",
-	"Output": "ipaddr:192.0.2.104",
+	"Output": "ipaddr:192.0.2.104\n",
 	"ServiceID": "redis",
 	"ServiceName": "redis"
       },


### PR DESCRIPTION
If client's output contains `\n`, Diff.IsChanged() goes wrong to compare `["192.168.0.1\n"]` and `["192.168.0.1"]`.

This will be fixed and version bumped.
