### PR TITLE
Get global ip from (cloud metadata) url by command-line option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: go
 
 go:
-  - 1.5
   - 1.6
 
 script:

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -35,7 +35,7 @@ This subcommand ins intendec to run under consul checker.`,
 func init() {
 	RootCmd.AddCommand(clientCmd)
 	clientCmd.Flags().StringVarP(&deviceName, "dev", "D", "eth0", "Device name which has the instance's global IP")
-	clientCmd.Flags().StringVarP(&url, "url", "U", "", "Get instance's global IP from URL")
+	clientCmd.Flags().StringVarP(&url, "url", "U", "", "Get instance's global IP from URL. (For example, http://169.254.169.254/latest/meta-data/public-ipv4)")
 }
 
 func runCheck(args []string) int {

--- a/collectorlib/request.go
+++ b/collectorlib/request.go
@@ -49,7 +49,7 @@ func (req Request) IPsByTag(tag string) []string {
 		}
 
 		for _, c := range check.Checks {
-			if c.CheckID == req.TargetCheckID && c.Status == "passing" {
+			if string(c.CheckID) == req.TargetCheckID && c.Status == "passing" {
 				ip := FindIPFromOutput(c.Output)
 				if ip != "" {
 					ips = append(ips, ip)


### PR DESCRIPTION
When instance has floating-ip, device does'nt have gip on device.
So, collector get floating-ip by command-line option's url.

example:

```
collector client --url http://169.254.169.254/latest/meta-data/public-ipv4
```